### PR TITLE
Policy validation: `key`: allow key that begins with '/'

### DIFF
--- a/src/amaging/stack/auth.js
+++ b/src/amaging/stack/auth.js
@@ -17,6 +17,18 @@ const hash = input =>
     .update(input)
     .digest('hex')
 
+const policySetKey = (policy, key) => {
+  try {
+    policy.set('key', key)
+  } catch (err) {
+    if (err.type === 'INVALID_KEY') {
+      policy.set('key', '/' + key)
+    } else {
+      throw err
+    }
+  }
+}
+
 export default () =>
   async function (req, res, next) {
     const { amaging } = req
@@ -59,7 +71,7 @@ export default () =>
 
       amaging.policy = policy
 
-      policy.set('key', params.file)
+      policySetKey(policy, params.file)
 
       amaging.auth.headers.forEach(header => {
         policy.set(header, req.headers[header])
@@ -99,7 +111,7 @@ export default () =>
 
           amaging.policy = policy
 
-          policy.set('key', params.file)
+          policySetKey(policy, params.file)
 
           amaging.auth.headers.forEach(header => {
             policy.set(header, req.headers[header])

--- a/test/policy_test.js
+++ b/test/policy_test.js
@@ -216,7 +216,7 @@ describe('Policy', () => {
         })
     })
 
-    return test(
+    test(
       'Should return a Forbidden when policy conditions are not correct',
       async () => {
         const pol = requestPolicyFileToken('expected/tente.jpg', {
@@ -251,6 +251,40 @@ describe('Policy', () => {
         expiration: '2025-01-01T00:00:00',
         conditions: [
           ['eq', 'action', 'create']
+        ]
+      })
+      const app = await appFactory()
+      await request(app)
+        .post('/test/policy/action-restriction/creation-allowed.jpg')
+        .set('x-authentication', 'apiaccess')
+        .set('x-authentication-policy', pol.policy)
+        .set('x-authentication-token', pol.token)
+        .attach('img', pol.file_path)
+        .expect(200)
+    })
+
+    test('Should return a 200 if key is allowed', async () => {
+      const pol = requestPolicyFileToken('expected/tente.jpg', {
+        expiration: '2025-01-01T00:00:00',
+        conditions: [
+          ['eq', 'key', 'policy/action-restriction/creation-allowed.jpg']
+        ]
+      })
+      const app = await appFactory()
+      await request(app)
+        .post('/test/policy/action-restriction/creation-allowed.jpg')
+        .set('x-authentication', 'apiaccess')
+        .set('x-authentication-policy', pol.policy)
+        .set('x-authentication-token', pol.token)
+        .attach('img', pol.file_path)
+        .expect(200)
+    })
+
+    test('Should return a 200 if key is allowed (with slash at begin)', async () => {
+      const pol = requestPolicyFileToken('expected/tente.jpg', {
+        expiration: '2025-01-01T00:00:00',
+        conditions: [
+          ['eq', 'key', '/policy/action-restriction/creation-allowed.jpg']
         ]
       })
       const app = await appFactory()


### PR DESCRIPTION
Fix amaging/igloo-amaging#25